### PR TITLE
Sniff original content encoding and insert `<meta charset="...">` tag before outputted article html

### DIFF
--- a/readability-extractor
+++ b/readability-extractor
@@ -40,7 +40,10 @@ JSDOM.fromFile(source_path).then(dom => {
   charset = dom.window.document.characterSet
   
   const article = getArticle(dom)
-  article['content'] = `<meta charset="${charset}">\n` + article['content']
+  //Readability parsing can fail and it will just return null
+  if (article !== null)
+    if (article['content'] !== null)
+      article['content'] = `<meta charset="${charset}">\n` + article['content']
   console.log(JSON.stringify(article))
 });
 

--- a/readability-extractor
+++ b/readability-extractor
@@ -9,7 +9,7 @@ Usage:
 */
 
 const source_path = process.argv[2]                                                            // e.g. ./archive/12345678910/singlefile.html
-const original_url = process.argv[3] || "https://example.com/unused-placeholder-url"           // e.g. https://exmaple.com/some/page.html
+const original_url = process.argv[3] || "https://example.com/url-was-not-specified"            // e.g. https://exmaple.com/some/page.html
 
 if (process.argv.includes("--version")) {
   const package_info = require('./package.json')
@@ -23,28 +23,32 @@ function getArticle(dom) {
 
   const window = dom.window
   const html = dom.serialize()
+
+  // strip potential XSS/JS in the article using DOMPurify library
   const DOMPurify = createDOMPurify(window)
-  const clean = DOMPurify.sanitize(html)
-  const doc = new JSDOM(clean, {url: original_url})
+  const cleaned_html = DOMPurify.sanitize(html)
+  const cleaned_dom = new JSDOM(cleaned_html, {url: original_url})
   
-  const reader = new Readability(doc.window.document)
-  return reader.parse()
+  // parse out the Article body text using Readability library
+  const reader = new Readability(cleaned_dom.window.document)
+  const article = reader.parse()
+
+  // Attach information about original source charset to output
+  const charset = dom.window.document.characterSet || cleaned_dom.window.document.characterSet
+  article['charset'] = charset
+  
+  if (article['content'] !== null) {
+      // prepend meta charset tag to html to hint to downstream renderers to use the correct original encoding
+      article['content'] = `<meta charset="${original_charset}">\n${article['content']}`
+  }
+  return article
 }
 
 const { JSDOM } = require('jsdom')
+// JSDOM uses the jsdom/html-encoding-sniffer library which implements the HTML standard sniffing algorithm.
+// JSDOM.fromFile is more robust at detecting the charset than from a string: https://github.com/jsdom/jsdom#encoding-sniffing
 
-//Determine the charset 
-//JSDOM uses the jsdom/html-encoding-sniffer library which implements the HTML standard sniffing algorithm.
-//JSDOM.fromFile is more robust at detecting the charset than from a string: https://github.com/jsdom/jsdom#encoding-sniffing
 JSDOM.fromFile(source_path).then(dom => {
-  charset = dom.window.document.characterSet
-
   const article = getArticle(dom)
-  //Readability parsing can fail and it will just return null
-  if (article !== null) {
-    if (article['content'] !== null && charset !== 'windows-1252') {
-      article['content'] = `<meta charset="${charset}">\n` + article['content']
-     }
-  }
   console.log(JSON.stringify(article))
 });

--- a/readability-extractor
+++ b/readability-extractor
@@ -17,22 +17,30 @@ if (process.argv.includes("--version")) {
   process.exit(0)
 }
 
-function getArticle(html) {
+function getArticle(dom) {
   const createDOMPurify = require('dompurify')
   const { Readability } = require('@mozilla/readability')
-  const { JSDOM } = require('jsdom')
-  
-  const window = new JSDOM("").window
+
+  const window = dom.window
+  const html = dom.serialize()
   const DOMPurify = createDOMPurify(window)
   const clean = DOMPurify.sanitize(html)
-  
   const doc = new JSDOM(clean, {url: original_url})
   
   const reader = new Readability(doc.window.document)
   return reader.parse()
 }
 
-const fs = require("fs")
+const { JSDOM } = require('jsdom')
 
-const html = fs.readFileSync(source_path).toString()
-console.log(JSON.stringify(getArticle(html)))
+//Determine the charset 
+//JSDOM uses the jsdom/html-encoding-sniffer library which implements the HTML standard sniffing algorithm.
+//JSDOM.fromFile is more robust at detecting the charset than from a string: https://github.com/jsdom/jsdom#encoding-sniffing
+JSDOM.fromFile(source_path).then(dom => {
+	charset = dom.window.document.characterSet
+
+	const article = getArticle(dom)
+	article['content'] = `<meta charset="${charset}">\n` + article['content']
+	console.log(JSON.stringify(article))
+});
+

--- a/readability-extractor
+++ b/readability-extractor
@@ -32,7 +32,6 @@ function getArticle(dom) {
 }
 
 const { JSDOM } = require('jsdom')
-const { htmlEncodingSniffer } = require('html-encoding-sniffer')
 
 //Determine the charset 
 //JSDOM uses the jsdom/html-encoding-sniffer library which implements the HTML standard sniffing algorithm.
@@ -49,5 +48,3 @@ JSDOM.fromFile(source_path).then(dom => {
   }
   console.log(JSON.stringify(article))
 });
-
-

--- a/readability-extractor
+++ b/readability-extractor
@@ -32,18 +32,22 @@ function getArticle(dom) {
 }
 
 const { JSDOM } = require('jsdom')
+const { htmlEncodingSniffer } = require('html-encoding-sniffer')
 
 //Determine the charset 
 //JSDOM uses the jsdom/html-encoding-sniffer library which implements the HTML standard sniffing algorithm.
 //JSDOM.fromFile is more robust at detecting the charset than from a string: https://github.com/jsdom/jsdom#encoding-sniffing
 JSDOM.fromFile(source_path).then(dom => {
   charset = dom.window.document.characterSet
-  
+
   const article = getArticle(dom)
   //Readability parsing can fail and it will just return null
-  if (article !== null)
-    if (article['content'] !== null)
+  if (article !== null) {
+    if (article['content'] !== null && charset !== 'windows-1252') {
       article['content'] = `<meta charset="${charset}">\n` + article['content']
+     }
+  }
   console.log(JSON.stringify(article))
 });
+
 

--- a/readability-extractor
+++ b/readability-extractor
@@ -37,10 +37,10 @@ const { JSDOM } = require('jsdom')
 //JSDOM uses the jsdom/html-encoding-sniffer library which implements the HTML standard sniffing algorithm.
 //JSDOM.fromFile is more robust at detecting the charset than from a string: https://github.com/jsdom/jsdom#encoding-sniffing
 JSDOM.fromFile(source_path).then(dom => {
-	charset = dom.window.document.characterSet
-
-	const article = getArticle(dom)
-	article['content'] = `<meta charset="${charset}">\n` + article['content']
-	console.log(JSON.stringify(article))
+  charset = dom.window.document.characterSet
+  
+  const article = getArticle(dom)
+  article['content'] = `<meta charset="${charset}">\n` + article['content']
+  console.log(JSON.stringify(article))
 });
 


### PR DESCRIPTION
Previously, character set information would be thrown out. This would crucially confuse browsers, sometimes they can't guess the encoding and end up rendering gibberish.

- Referenced in https://github.com/ArchiveBox/ArchiveBox/pull/1059

## Output now:
Test at: https://github.com/jsdom/html-encoding-sniffer/blob/master/test/utf-16le-bom.html

```sh
readability-extractor utf-16le-bom.html 'https://example.org/'
```

```json
{"title":"","byline":null,"dir":null,"content":"<meta charset=\"UTF-16LE\">\n<div id=\"readability-page-1\" class=\"page\">©\n</div>","textContent":"©\n","length":2,"siteName":null}
```

Output before wouldn't have <meta charset=\"UTF-16LE\">\n. You can find more tests here: https://github.com/jsdom/html-encoding-sniffer/tree/master/test